### PR TITLE
Remove our connection configuration code

### DIFF
--- a/lib/commands/cleanup.coffee
+++ b/lib/commands/cleanup.coffee
@@ -4,7 +4,6 @@ minimist = require 'minimist'
 
 ConsoleReporter = require '../lib/console_reporter'
 Docker = require 'dockerode'
-DockerConfig = require '../lib/docker_config'
 DockerUtils = require '../lib/docker_utils'
 PromiseUtils = require '../lib/promise_utils'
 ServiceHelpers = require '../lib/service_helpers'
@@ -84,7 +83,7 @@ module.exports = (args, commandOptions, done) ->
   if argv._.length isnt 0 or argv.help
     return help args, commandOptions, done
 
-  docker = new Docker(DockerConfig.connectionConfig())
+  docker = new Docker()
 
   options =
     unprotectStateful: argv.unprotectStateful

--- a/lib/commands/pull.coffee
+++ b/lib/commands/pull.coffee
@@ -70,7 +70,7 @@ module.exports = (args, commandOptions, done) ->
     return help args, commandOptions, done
 
   {servicesConfig} = ServiceHelpers.processConfig commandOptions.config, env, options.add
-  docker = new Docker(DockerConfig.connectionConfig())
+  docker = new Docker()
 
   pullService docker, servicesConfig, service, env
     .then -> done?()

--- a/lib/commands/run.coffee
+++ b/lib/commands/run.coffee
@@ -904,7 +904,7 @@ module.exports = (args, commandOptions, done) ->
   unless service? and not _.isEmpty(service)
     return help args, commandOptions, done
 
-  dockerConfig = DockerConfig.connectionConfig()
+  docker = new Docker()
 
   options.stdin = commandOptions.stdin or process.stdin
   options.stderr = commandOptions.stderr or process.stderr
@@ -913,7 +913,7 @@ module.exports = (args, commandOptions, done) ->
   options.reporter = commandOptions.reporter or new ConsoleReporter(options.stderr)
   options.stdinCommandInterceptor = new StdinCommandInterceptor(options.stdin)
 
-  options.localhostForwarder = new LocalhostForwarder(dockerConfig, options.reporter)
+  options.localhostForwarder = new LocalhostForwarder(docker.modem, options.reporter)
 
   throw "Missing env for service #{service}. Format: <service>.<env>" unless env
 
@@ -925,8 +925,6 @@ module.exports = (args, commandOptions, done) ->
   # We want to generate this before prepareServiceSource so that its potential modifications
   # to "volumesFrom" don't appear as additional prereq services.
   services = ServiceHelpers.generatePrereqServices(service, servicesConfig)
-
-  docker = new Docker(dockerConfig)
 
   sighupHandler = options.stdinCommandInterceptor.sighup.bind(options.stdinCommandInterceptor)
   process.on 'SIGHUP', sighupHandler

--- a/lib/commands/stop_env.coffee
+++ b/lib/commands/stop_env.coffee
@@ -1,7 +1,6 @@
 _ = require 'lodash'
 ConsoleReporter = require '../lib/console_reporter'
 Docker = require 'dockerode'
-DockerConfig = require '../lib/docker_config'
 RSVP = require 'rsvp'
 help = require './help'
 
@@ -18,7 +17,7 @@ stopContainer = (name, container, reporter) ->
       resolve()
 
 module.exports = (args, options, done) ->
-  docker = new Docker(DockerConfig.connectionConfig())
+  docker = new Docker()
 
   if args.length isnt 1
     return help args, options, done

--- a/lib/lib/docker_config.coffee
+++ b/lib/lib/docker_config.coffee
@@ -5,24 +5,6 @@ _ = require 'lodash'
 homeDir = require 'home-dir'
 
 module.exports =
-  connectionConfig: ->
-    hostUrl = url.parse process.env.DOCKER_HOST or ''
-
-    dockerOpts = if hostUrl.hostname
-      host: hostUrl.hostname
-      port: hostUrl.port
-    else
-      socketPath: process.env.DOCKER_HOST or '/var/run/docker.sock'
-
-    if (certPath = process.env.DOCKER_CERT_PATH)
-      _.merge dockerOpts,
-        protocol: 'https'
-        ca: fs.readFileSync "#{certPath}/ca.pem"
-        cert: fs.readFileSync "#{certPath}/cert.pem"
-        key: fs.readFileSync "#{certPath}/key.pem"
-
-    dockerOpts
-
   # Checks the user's docker config file for login information. The file is a JSON hash, and there are two
   # versions, in two different locations.
   #

--- a/lib/lib/localhost_forwarder.coffee
+++ b/lib/lib/localhost_forwarder.coffee
@@ -3,8 +3,8 @@ tcpProxy = require 'tcp-proxy'
 # Class to run TCP proxies from the localhost in to a boot2docker VM. Useful for when you need
 # devices outside of the host machine to connect in to a container.
 class LocalhostForwarder
-  constructor: (dockerConfig, reporter) ->
-    @dockerConfig = dockerConfig
+  constructor: (modem, reporter) ->
+    @modem = modem
     @reporter = reporter
 
   # Returns either a receipt object with a "stop" method, or null if forwarding is
@@ -15,19 +15,19 @@ class LocalhostForwarder
   forward: (ports) ->
     # If we're connecting to Docker via socket, assume that containers are running on the same host
     # as Galley, so there's no need to forward.
-    return if @dockerConfig.socketPath?
+    return if @modem.socketPath?
 
     servers = for port in ports
       server = tcpProxy.createServer
         target: 
-          host: @dockerConfig.host
+          host: @modem.host
           port: port
 
       server.listen port
 
       # "do" shenanigans since "port" mutates inside the loop.
       server.on 'error', do (port) =>
-        (err) => @reporter.error "Failure proxying to #{@dockerConfig.host}:#{port}: #{err}"
+        (err) => @reporter.error "Failure proxying to #{@modem.host}:#{port}: #{err}"
 
       server
 


### PR DESCRIPTION
The _.merge in DockerConfig was converting Buffers containing the PEM
data into arrays of bytes. This broke the TLS client authentication in
Node 4+.

Removing the code completely, since it dates to when docker-modem didn't
support getting this info on its own. Since it can now pull the daemon
auth information out of the environment, we'll just rely on it to do so.
