### PR TITLE
Out-of-the box rsync support

### DIFF
--- a/descriptions/rsync/Dockerfile
+++ b/descriptions/rsync/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:14.04
+
+RUN apt-get update && apt-get install -y \
+  rsync
+
+COPY etc /etc
+
+EXPOSE 873
+CMD ["/usr/bin/rsync", "--no-detach", "--daemon"]

--- a/descriptions/rsync/etc/rsyncd.conf
+++ b/descriptions/rsync/etc/rsyncd.conf
@@ -1,0 +1,10 @@
+uid = root
+gid = root
+use chroot = yes
+
+log file = /dev/stdout
+
+[root]
+    read only = false
+    path = /
+    comment = docker volume

--- a/lib/lib/service_helpers.coffee
+++ b/lib/lib/service_helpers.coffee
@@ -146,6 +146,11 @@ processConfig = (galleyfileValue, env, requestedAddons) ->
   globalConfig = galleyfileValue.CONFIG or {}
   globalAddons = galleyfileValue.ADDONS or {}
 
+  unless globalConfig.rsync?
+    globalConfig.rsync =
+      image: 'galley/rsync'
+      module: 'root'
+
   servicesConfig = _.mapValues galleyfileValue, (serviceConfig, service) ->
     return if service is 'CONFIG'
 

--- a/spec/service_helpers_spec.coffee
+++ b/spec/service_helpers_spec.coffee
@@ -375,3 +375,7 @@ describe 'processConfig', ->
     it 'returns global config', ->
       expect(ServiceHelpers.processConfig(CONFIG, 'dev', []).globalConfig).toEqual
         registry: 'docker.example.tv'
+        # rsync config is default
+        rsync:
+          image: 'galley/rsync'
+          module: 'root'


### PR DESCRIPTION
Adds default configuration to use the galley/rsync container from the
Docker Hub. Also adds Dockerfile description for that container.
