### PR TITLE
Fixes Volume detection for Docker API 1.20+

### DIFF
--- a/acceptance/Galleyfile.coffee
+++ b/acceptance/Galleyfile.coffee
@@ -1,3 +1,12 @@
+# You can test this Galleyfile locally w/ galley commands! There's a bit of a trick to getting
+# galley to resolve correctly.
+#
+# In the directory above this, run:
+#  $ npm link; npm link galley
+#
+# This will make it so that galley-cli run in this directory will recur up to find galley's own
+# package.json, and from there be able to resolve 'galley'.
+
 module.exports =
   CONFIG:
     rsync:

--- a/acceptance/Galleyfile.js
+++ b/acceptance/Galleyfile.js
@@ -1,0 +1,3 @@
+// CoffeeScript shim for local testing
+require('coffee-script/register');  
+module.exports = require('./Galleyfile.coffee');


### PR DESCRIPTION
API change removed "Volumes" entry and added "Mounts" to container
inspection JSON. Fix was caught by acceptance tests running with
latest version of Docker.

Also adds shim to allow for testing of acceptance containers via
galley-cli.
