### PR TITLE
Fixes up printing of addons in list

### DIFF
--- a/acceptance/acceptance_spec.coffee
+++ b/acceptance/acceptance_spec.coffee
@@ -88,6 +88,19 @@ describe 'galley', ->
         .then ->
           testCommands.stopEnv ENV
 
+  describe 'list', ->
+    it 'prints addons and services with environments', ->
+      testCommands.list()
+      .then ({out}) ->
+        expect(out).toEqual '''
+Galleyfile: ./Galleyfile.js
+  application -a backend-addon
+  backend [.galley-integration]
+  config
+  database
+
+'''
+
   describe 'basics', ->
     # Base test to show that we're starting everything up correctly.
     it 'starts up prereq services', ->

--- a/acceptance/test_commands.coffee
+++ b/acceptance/test_commands.coffee
@@ -10,6 +10,7 @@ TestReporter = require '../spec/util/test_reporter'
 
 cleanupCommand = require '../lib/commands/cleanup'
 runCommand = require '../lib/commands/run'
+listCommand = require '../lib/commands/list'
 stopEnvCommand = require '../lib/commands/stop_env'
 
 GALLEYFILE = require './Galleyfile'
@@ -62,6 +63,19 @@ cleanup = ->
       resolve
         reporter: options.reporter
 
+list = ->
+  new RSVP.Promise (resolve, reject) ->
+    outBuffer = new streamBuffers.WritableStreamBuffer(frequency: 0)
+    options =
+      config: GALLEYFILE
+      configPath: './Galleyfile.js'
+      stdout: outBuffer
+
+    listCommand [], options, ->
+      resolve
+        # Strip out chalk ASCII codes before returning
+        out: outBuffer.getContentsAsString().replace(/\x1b\[\d+m/g, '')
+
 stopEnv = (env) ->
   new RSVP.Promise (resolve, reject) ->
     stopEnvCommand [env], {reporter: new TestReporter}, resolve
@@ -70,5 +84,6 @@ module.exports = {
   exec
   run
   cleanup
+  list
   stopEnv
 }

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -66,6 +66,7 @@ run = (galleyfilePath, argv) ->
 
   opts =
     config: require galleyfilePath
+    configPath: galleyfilePath
     globalOptions: loadGlobalOptionsSync()
 
   args = process.argv.slice 2

--- a/lib/lib/service_helpers.coffee
+++ b/lib/lib/service_helpers.coffee
@@ -191,7 +191,7 @@ envsFromServiceConfig = (serviceConfig) ->
   definedEnvs = definedEnvs.concat(envEnvs)
   _.unique _.flatten definedEnvs
 
-listServicesWithEnvs = (galleyfileValue) ->
+envsByService = (galleyfileValue) ->
   serviceList = _.mapValues galleyfileValue, (serviceConfig, service) ->
     return if service is 'CONFIG' or service is 'ADDONS'
     envsFromServiceConfig serviceConfig
@@ -200,9 +200,14 @@ listServicesWithEnvs = (galleyfileValue) ->
   delete serviceList.ADDONS
   serviceList
 
-listAddons = (galleyfileValue) ->
+addonsByService = (galleyfileValue) ->
   addons = galleyfileValue['ADDONS'] or {}
-  _.keys(addons)
+  _.tap {}, (serviceAddonMap) ->
+    for addon, servicesMap of addons
+      for service, infoMap of servicesMap
+        serviceAddonMap[service] ||= []
+        serviceAddonMap[service].push addon
+        serviceAddonMap[service].sort()
 
 # Generates an array of prerequisite services of a service, from the configuration file.
 # The last element of returned array is the requested service,
@@ -248,7 +253,7 @@ module.exports = {
   combineAddons
   collapseServiceConfigEnv
   processConfig
-  listServicesWithEnvs
-  listAddons
+  envsByService
+  addonsByService
 }
 

--- a/spec/service_helpers_spec.coffee
+++ b/spec/service_helpers_spec.coffee
@@ -289,7 +289,7 @@ describe 'addDefaultNames', ->
       image: 'application'
       name: 'application'
 
-describe 'listServicesWithEnvs', ->
+describe 'envsByService', ->
   describe 'envs', ->
     CONFIG =
       service:
@@ -314,11 +314,11 @@ describe 'listServicesWithEnvs', ->
         image: 'application'
 
     it 'processes services', ->
-      expect(ServiceHelpers.listServicesWithEnvs(CONFIG)).toEqual
+      expect(ServiceHelpers.envsByService(CONFIG)).toEqual
         'application': []
         'service': ['dev', 'dev.namespace', 'test', 'other']
 
-describe 'listAddons', ->
+describe 'addonsByService', ->
   describe 'envs', ->
     CONFIG =
       ADDONS:
@@ -326,9 +326,19 @@ describe 'listAddons', ->
           service:
             links:
               'dev': ['database']
+          service2:
+            links:
+              'dev': ['database']
+        myaddon2:
+          service: {}
+          service3: {}
 
     it 'processes addons', ->
-      expect(ServiceHelpers.listAddons(CONFIG)).toEqual ['myaddon']
+      expect(ServiceHelpers.addonsByService(CONFIG)).toEqual {
+        'service': ['myaddon', 'myaddon2']
+        'service2': ['myaddon']
+        'service3': ['myaddon2']
+      }
 
 describe 'processConfig', ->
   describe 'naming', ->


### PR DESCRIPTION
Moves addons to be put next to the services that are modified by them.
Also includes the path to the Galleyfile.

Possibly broken after switch to global ADDONS in the Galleyfile. Also
added smoke regression test for list command.
