### PR TITLE
Add support for pulling private images from private Docker Hub-style registries

### DIFF
--- a/lib/lib/docker_utils.coffee
+++ b/lib/lib/docker_utils.coffee
@@ -86,7 +86,7 @@ resizeContainer = (container, ttyStream) ->
 # calls the progressCb function with either undefined or an interesting progress string.
 #
 # Does not resolve to a value.
-downloadImage = (docker, imageName, authConfigFn, progressCb = ->) ->
+downloadImage = (docker, imageName, globalRegistry, authConfigFn, progressCb = ->) ->
   new RSVP.Promise (resolve, reject) ->
     opts = {}
 
@@ -97,6 +97,8 @@ downloadImage = (docker, imageName, authConfigFn, progressCb = ->) ->
       repository = imageName.split('/')[0]
       if repository.indexOf('.') isnt -1
         opts.authconfig = authConfigFn(repository)
+      else
+        opts.authconfig = authConfigFn(globalRegistry)
 
     docker.pull imageName, opts, (err, stream) ->
       return reject(err) if err


### PR DESCRIPTION
Addresses #24 

This works for me and resolves the original problem I was seeing.

I updated `registry` in my `Galleyfile` to match the `~/.docker/config.json` auth block:

````
    registry: 'https://index.docker.io/v1/',
````
