### PR TITLE
Correctly exposes Galleyfile ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,8 @@ can be a hash of environment name to array of links.
 
 **ports**: Array of ports to publish when the service is run as the primary service. Array values are either
 `"host_port:container_port"` or `"container_port"`. If a host port is ommitted, Docker will assign a random host
-port to proxy in. Alternately, can be a hash of environment name to array of port values.
+port to proxy in. Alternately, can be a hash of environment name to array of port values. Ports need not be
+exposed by the Dockerfile.
 
 **restart**: Boolean. If `true`, applies a Docker `RestartPolicy` of “always” to the container. Default is `false`.
 

--- a/lib/commands/run.coffee
+++ b/lib/commands/run.coffee
@@ -50,9 +50,7 @@ makeCreateOpts = (imageInfo, serviceConfig, servicesMap, options) ->
   if serviceConfig.publishPorts
     {portBindings, exposedPorts} = DockerArgs.formatPortBindings(serviceConfig.ports)
     createOpts['HostConfig']['PortBindings'] = portBindings
-    unless exposedPorts is {}
-      createOpts['ExposedPorts'] = exposedPorts
-      createOpts['HostConfig']['PublishAllPorts'] = true
+    createOpts['ExposedPorts'] = exposedPorts
 
   # Note container labels and values (as of Docker 1.6) can only be strings
   if serviceConfig.primary?

--- a/spec/docker_args_spec.coffee
+++ b/spec/docker_args_spec.coffee
@@ -37,8 +37,8 @@ describe 'DockerArgs', ->
     it 'should return portBindings and exposedPorts', ->
       ports = ['3200:3000', '8506']
       expect(DockerArgs.formatPortBindings(ports)).toEqual
-        portBindings: {'3000/tcp': [{'HostPort': '3200'}]}
-        exposedPorts: {'8506/tcp': {}}
+        portBindings: {'3000/tcp': [{'HostPort': '3200'}], '8506/tcp': [{'HostPort': null}]}
+        exposedPorts: {'3000/tcp': {}, '8506/tcp': {}}
 
   describe 'formatVolumes', ->
     it 'should return volumes', ->


### PR DESCRIPTION
Makes it so any port requested by the Galleyfile is exposed, regardless
of EXPOSE commands in the Dockerfile. Removes incorrect use of
PublishAllPorts.

Fix for #23.