### PR TITLE
support udp port mappings

### DIFF
--- a/lib/lib/docker_args.coffee
+++ b/lib/lib/docker_args.coffee
@@ -19,9 +19,10 @@ formatLinks = (links, containerNameMap) ->
     containerName = containerNameMap[service]
     "#{containerName}:#{alias}"
 
-# Given a list of ports of the form "<host>:<container>" or just "<container>", returns a hash of
-# portBindings and exposedPorts. We always expose every port specified so we can map ports
-# regardless of EXPOSE commands in the Dockerfile.
+# Given a list of ports in one of the following forms:
+# "<host>:<container>", "<container>", "<host>:<container>/<protocol>", "<container>/<protocol>",
+# returns a hash of portBindings and exposedPorts. We always expose every port specified so we
+# can map ports regardless of EXPOSE commands in the Dockerfile.
 #
 # These go into the HostConfig.Ports and ExposedPorts keys for container creation, respectively.
 formatPortBindings = (ports) ->
@@ -29,11 +30,9 @@ formatPortBindings = (ports) ->
   exposedPorts = {}
 
   for port in ports
-    [dst, src] = port.split(':')
-    [src, protocol] = if src? && src.indexOf('/') > 0 then src.split('/') else [src, 'tcp']
-    unless src?
-      src = dst
-      dst = null
+    [dst, src, protocol] = port.match(/(?:(\d+)?:)?(\d+)\/?(tcp|udp)?/).slice(1)
+    protocol ||= 'tcp'
+    dst ||= null
 
     # If dst is null then Docker will allocate an unused port
     portBindings["#{src}/#{protocol}"] = [{'HostPort': dst}]

--- a/lib/lib/docker_args.coffee
+++ b/lib/lib/docker_args.coffee
@@ -30,13 +30,14 @@ formatPortBindings = (ports) ->
 
   for port in ports
     [dst, src] = port.split(':')
+    [src, protocol] = if src? && src.indexOf('/') > 0 then src.split('/') else [src, 'tcp']
     unless src?
       src = dst
       dst = null
 
     # If dst is null then Docker will allocate an unused port
-    portBindings["#{src}/tcp"] = [{'HostPort': dst}]
-    exposedPorts["#{src}/tcp"] = {}
+    portBindings["#{src}/#{protocol}"] = [{'HostPort': dst}]
+    exposedPorts["#{src}/#{protocol}"] = {}
 
   {portBindings, exposedPorts}
 

--- a/spec/docker_args_spec.coffee
+++ b/spec/docker_args_spec.coffee
@@ -35,10 +35,10 @@ describe 'DockerArgs', ->
 
   describe 'formatPortBindings', ->
     it 'should return portBindings and exposedPorts', ->
-      ports = ['3200:3000', '8506']
+      ports = ['3200:3000', '8506', '5555:4444/udp']
       expect(DockerArgs.formatPortBindings(ports)).toEqual
-        portBindings: {'3000/tcp': [{'HostPort': '3200'}], '8506/tcp': [{'HostPort': null}]}
-        exposedPorts: {'3000/tcp': {}, '8506/tcp': {}}
+        portBindings: {'3000/tcp': [{'HostPort': '3200'}], '8506/tcp': [{'HostPort': null}], '4444/udp': [{'HostPort': '5555'}]}
+        exposedPorts: {'3000/tcp': {}, '8506/tcp': {}, '4444/udp': {}}
 
   describe 'formatVolumes', ->
     it 'should return volumes', ->

--- a/spec/docker_args_spec.coffee
+++ b/spec/docker_args_spec.coffee
@@ -35,10 +35,10 @@ describe 'DockerArgs', ->
 
   describe 'formatPortBindings', ->
     it 'should return portBindings and exposedPorts', ->
-      ports = ['3200:3000', '8506', '5555:4444/udp']
+      ports = ['3200:3000', '8506', '5555:4444/udp', '7777/udp']
       expect(DockerArgs.formatPortBindings(ports)).toEqual
-        portBindings: {'3000/tcp': [{'HostPort': '3200'}], '8506/tcp': [{'HostPort': null}], '4444/udp': [{'HostPort': '5555'}]}
-        exposedPorts: {'3000/tcp': {}, '8506/tcp': {}, '4444/udp': {}}
+        portBindings: {'3000/tcp': [{'HostPort': '3200'}], '8506/tcp': [{'HostPort': null}], '4444/udp': [{'HostPort': '5555'}], '7777/udp': [{'HostPort': null}]}
+        exposedPorts: {'3000/tcp': {}, '8506/tcp': {}, '4444/udp': {}, '7777/udp': {}}
 
   describe 'formatVolumes', ->
     it 'should return volumes', ->


### PR DESCRIPTION
in order to communicate with services like riemann or statsd, port mappings need to support udp as well as tcp

I seem to have a failing acceptance test, but the same test fails on master for me.

```
~/src/galley (adamvduke/add-udp-port-mapping-support)$ gulp compile && gulp test && gulp acceptance
[16:46:38] Using gulpfile /crashlytics/galley/gulpfile.js
[16:46:38] Starting 'compile'...
[16:46:39] Finished 'compile' after 454 ms
[16:46:40] Using gulpfile /crashlytics/galley/gulpfile.js
[16:46:40] Starting 'test'...


  DockerArgs
    formatEnvVariables
      ✓ should be a list for Docker
      ✓ excludes nulls but includes empty strings
    formatLinks
      ✓ should format links, looking up container names
    formatPortBindings
      ✓ should return portBindings and exposedPorts
    formatVolumes
      ✓ should return volumes
    formatVolumesFrom
      ✓ looks up some services but not others

  PromiseUtils
    promiseEach
      ✓ resolves after each promise resolves
      ✓ rejects if a value rejects

  parseArgs
    addons option support
      with a single value
        ✓ should generate addon options with an array with one value
      with a multiple values through multiple params
        ✓ should generate addon options with an array with multiple values
      with a multiple values through a single delimited param
        ✓ should generate addon options with an array with multiple values
      with a trailing comma
        ✓ should generate addon options that do not include an empty string
      with a mix of delimited and non-delimited params
        ✓ should generate addon options with an array with multiple values
      with the long param name
        ✓ should generate the addon options as usual
      with the parameter not specified
        ✓ should generate an empty array of addons

  normalizeMultiArgs
    with a non-delimited string
      ✓ should be an array with one value
    with a delimited string with two values
      ✓ should be an array with two values
    with a delimited string with a bad leading comma
      ✓ should be an array with one value
    with a delimited string with a bad trailing comma
      ✓ should be an array with one value
    with an array with one value
      ✓ should be an array with one value
    with an array with one value
      ✓ should be an array with one value
    with an array with two values
      ✓ should be an array with two values
    with an array with two values, one of which is delimited
      ✓ should be an array with three values

  normalizeVolumeArgs
    ✓ handles a single value
    ✓ handles multiple values
    ✓ resolves relative paths

  generatePrereqServices
    generates simple dependency chain
      ✓ should generate correctly ordered list
    does not have duplicate service entries, keeps the earliest
      ✓ should generate correctly ordered list
    fails on circular dependency
      ✓ should throw

  collapseEnvironment
    not parameterized
      ✓ does not modify a string
      ✓ does not modify an array
    parameterized
      ✓ returns defaultValue when env is missing
      ✓ finds named environment
      ✓ finds namespaced environment
      ✓ falls back when namespace is missing

  collapseServiceConfigEnv
    array parameterization
      ✓ collapses down to just the environment
    env parameterization
      ✓ paramerizes the env variables

  combineAddons
    addons
      array parameter merging
        without env
          ✓ merges addons array parameters with addon
        with addon env
          ✓ merges addons array parameters with addon env
        with addon namespaced env
          ✓ merges addons array parameters with namespaced addon env
      env parameter merging
        with no base env
          ✓ parametrizes the env variables
        with a base env
          ✓ parametrizes the env variables
        with multiple addons
          ✓ paramerizes the env variables

  addDefaultNames
    ✓ preserves existing image name
    ✓ adds missing image name
    ✓ tolerates no registry

  envsByService
    envs
      ✓ processes services

  addonsByService
    envs
      ✓ processes addons

  processConfig
    naming
      ✓ processes services
      ✓ returns global config


  50 passing (42ms)

[16:46:40] Finished 'test' after 221 ms
[16:46:40] Using gulpfile /crashlytics/galley/gulpfile.js
[16:46:40] Starting 'acceptance'...
[16:46:40] Starting 'acceptance:build'...
Sending build context to Docker daemon 2.048 kB
Step 0 : FROM ubuntu:14.04
 ---> 8693db7e8a00
Step 1 : RUN apt-get update && apt-get install -y   curl   nodejs   npm
 ---> Using cache
 ---> 4e8c24344e5e
Step 2 : RUN ln -s /usr/bin/nodejs /usr/bin/node
 ---> Using cache
 ---> ab7811af2fcb
Step 3 : RUN npm install -g http-server@0.7.4
 ---> Using cache
 ---> 8a8f996c2b70
Successfully built 8a8f996c2b70
Sending build context to Docker daemon 6.144 kB
Step 0 : FROM galley-integration-base
 ---> 8a8f996c2b70
Step 1 : COPY src /src
 ---> Using cache
 ---> 4991f8db616c
Step 2 : WORKDIR /src
 ---> Using cache
 ---> 67f1b1e3acf1
Step 3 : CMD /usr/bin/node server.js
 ---> Using cache
 ---> 7d7867436f31
Step 4 : EXPOSE 9615
 ---> Using cache
 ---> fc6b46311c23
Successfully built fc6b46311c23
Sending build context to Docker daemon 2.048 kB
Step 0 : FROM galley-integration-base
 ---> 8a8f996c2b70
Step 1 : CMD curl http://backend:9615/
 ---> Using cache
 ---> 1621c7713485
Successfully built 1621c7713485
Sending build context to Docker daemon 3.584 kB
Step 0 : FROM galley-integration-base
 ---> 8a8f996c2b70
Step 1 : COPY config /config
 ---> Using cache
 ---> 3b8215eac958
Step 2 : VOLUME /config
 ---> Using cache
 ---> c355bc2b2a0f
Successfully built c355bc2b2a0f
Sending build context to Docker daemon 3.584 kB
Step 0 : FROM galley-integration-base
 ---> 8a8f996c2b70
Step 1 : COPY data /data
 ---> Using cache
 ---> 8282ab48b41d
Step 2 : CMD /usr/local/bin/http-server /data
 ---> Using cache
 ---> ab3c0dcf329d
Step 3 : EXPOSE 8080
 ---> Using cache
 ---> 3b87d7f3e27a
Successfully built 3b87d7f3e27a
Sending build context to Docker daemon 3.584 kB
Step 0 : FROM galley-integration-base
 ---> 8a8f996c2b70
Step 1 : RUN apt-get update && apt-get install -y   rsync
 ---> Using cache
 ---> c6d0a847449a
Step 2 : COPY etc /etc
 ---> Using cache
 ---> dfc89a34c0b5
Step 3 : EXPOSE 873
 ---> Using cache
 ---> 9c9a0bd7d995
Step 4 : CMD /usr/bin/rsync --no-detach --daemon
 ---> Using cache
 ---> 4c1024498a76
Successfully built 4c1024498a76
[16:46:42] Finished 'acceptance:build' after 1.96 s
[16:46:42] Starting 'acceptance:test'...


  galley
    cleanup
      ✓ removes everything except stateful (1297ms)
    list
      ✓ prints addons and services with environments
    basics
      ✓ starts up prereq services (664ms)
      ✓ preserves running services (1768ms)
    commands
      1) allows source, entrypoint, and new command
      ✓ sets env variables, pipes stdin through correctly (631ms)
    links
      ✓ creates removed linked-to services (1528ms)
      ✓ recreates services with removed linked-to services (1075ms)
      ✓ uses existing backend container (2036ms)
    volumes
      ✓ recreates after volume is deleted (875ms)


  9 passing (17s)
  1 failing

  1) galley commands allows source, entrypoint, and new command:
     Error: /src/code.txt failed with exit code 1
    at build/acceptance/test_commands.js:63:23
    at build/lib/commands/run.js:922:12
    at lib$rsvp$$internal$$tryCatch (node_modules/rsvp/dist/rsvp.js:493:16)
    at lib$rsvp$$internal$$invokeCallback (node_modules/rsvp/dist/rsvp.js:505:17)
    at lib$rsvp$$internal$$publish (node_modules/rsvp/dist/rsvp.js:476:11)
    at lib$rsvp$asap$$flush (node_modules/rsvp/dist/rsvp.js:1198:9)
  



[16:46:59] 'acceptance:test' errored after 17 s
[16:46:59] Error in plugin 'gulp-mocha'
Message:
    1 test failed.
[16:46:59] 'acceptance' errored after 19 s
[16:46:59] Error in plugin 'run-sequence'
Message:
    An error occured in task 'acceptance:test'.
```