### PR TITLE
fix travis.ci badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Galley](docs/images/galley-red.png)
 
 
-[![Travis](https://img.shields.io/travis/rust-lang/rust.svg)](https://github.com/twitter-fabric/galley)
+[![Build Status](https://travis-ci.org/twitter-fabric/galley.svg?branch=master)](https://travis-ci.org/twitter-fabric/galley)
 
 ## Overview
 


### PR DESCRIPTION
Looks like the current badge is the rust-lang build and the link goes back to the repo when it should display the galley build and link to the build on travis-ci.org.