### PR TITLE
Add support for docker >= 1.10

### DIFF
--- a/acceptance/acceptance_spec.coffee
+++ b/acceptance/acceptance_spec.coffee
@@ -34,11 +34,11 @@ APPLICATION_SUCCESS =
 # to test the staleness behavior.
 resetTags = ->
   RSVP.all([
-    testCommands.exec 'docker tag -f galley-integration-backend:original galley-integration-backend'
-    testCommands.exec 'docker tag -f galley-integration-database:original galley-integration-database'
-    testCommands.exec 'docker tag -f galley-integration-application:original galley-integration-application'
-    testCommands.exec 'docker tag -f galley-integration-config:original galley-integration-config'
-    testCommands.exec 'docker tag -f galley-integration-rsync:original galley-integration-rsync'
+    testCommands.exec 'docker tag galley-integration-backend:original galley-integration-backend'
+    testCommands.exec 'docker tag galley-integration-database:original galley-integration-database'
+    testCommands.exec 'docker tag galley-integration-application:original galley-integration-application'
+    testCommands.exec 'docker tag galley-integration-config:original galley-integration-config'
+    testCommands.exec 'docker tag galley-integration-rsync:original galley-integration-rsync'
   ])
 
 removeContainers = ->

--- a/lib/lib/docker_utils.coffee
+++ b/lib/lib/docker_utils.coffee
@@ -31,7 +31,11 @@ inspectContainer = (container) ->
 startContainer = (container, opts = {}) ->
   new RSVP.Promise (resolve, reject) ->
     container.start opts, (err) ->
-      if err then reject(err) else resolve({container})
+      if err
+        err.container = container
+        reject(err)
+      else
+        resolve({container})
 
 stopContainer = (container, opts = {}) ->
   new RSVP.Promise (resolve, reject) ->


### PR DESCRIPTION
Fix #40: recreate broken links on docker >= 1.10

Docker 1.10 changed the behavior of links when a container dies, see
https://github.com/docker/docker/issues/21049

This PR extends the logic in isLinkMissing to check if a linked
container is newer than the linking container. If it is it couldn't
possibly be actually linked since links can only be set at container
creation time. This heuristic is used to recreate containers that
crashed or stopped (but were still included as present in another
containers links) preventing the errors reported in #40.