### PR TITLE
Galley version 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Next Release
 #### Bug fixes
+#### Features
+
+
+### v1.1.1 (2016-06-27):
+#### Bug fixes
 - Fix a bug that prevented starting services that aliased links.
 
 ### v1.1.0 (2016-06-24):

--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ and test environments. Galley automatically starts a container’s dependencies 
 start up a web server, its database, an intermediate data service (and its database), some queues, worker processes, and
 the monitoring server they all connect to.
 
-**Latest version:** 1.1.0
+**Latest version:** 1.1.1
 
- - Fix recreation logic for missing links on Docker >= 1.10
+ - Fix recreation logic for missing links on Docker >= 1.10 (#40)
+ - Fix a bug that prevented starting services that aliased links.
 
 ### What makes Galley different?
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galley",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Galley is a Docker container orchestator for development and testing.",
   "main": "build/lib/index.js",
   "scripts": {


### PR DESCRIPTION
- Fix a bug that prevented starting services that aliased links.