### PR TITLE
Prevent a crash when requesting help for an unknown command

### DIFF
--- a/lib/commands/help.coffee
+++ b/lib/commands/help.coffee
@@ -178,7 +178,7 @@ printHelp = (args, helps) ->
       printHelp args, helps[command]
     else
       print "Error: Unrecognized argument: #{command}"
-      printHelp args, helps['']
+      printHelp args, helps['_']
       process.exit 1
 
 module.exports = (args, options, done) ->


### PR DESCRIPTION
Just show the root help message instead