### PR TITLE
Update coffeescript to 1.10.1 to prevent NPE in catch block

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "node": ">= 5.0.0"
   },
   "devDependencies": {
-    "coffee-script": "^1.9.0",
+    "coffee-script": "^1.10.0",
     "del": "^2.2.1",
     "expect": "^1.3.0",
     "gulp": "^3.8.10",
     "gulp-changed": "^1.0.0",
-    "gulp-coffee": "^2.2.0",
+    "gulp-coffee": "^2.3.2",
     "gulp-load-plugins": "^1.2.4",
     "gulp-mocha": "^2.0.0",
     "gulp-notify": "^2.0.1",


### PR DESCRIPTION
When galley crashes, there is a NPE happening in the catch block when trying to format the error message. It's calling `ref.message.trim()`. but `ref.message` is undefined. The coffeescript code actually is correct is preventing this from happening, but we're using an older version of coffeescript that transpiles the line different than how we'd expect, leading in JS code that's vulnerable to this NPE. Upgrading coffeescript to 1.10.0 correctly transpiles the null-safe code.

Original line:
`message = err.json?.message?.trim() or ((err if typeof err is 'string') or err.message or 'Unknown error').trim()`

Transpiled using CS 1.9.0:
`message = ((ref = err.json) != null ? (ref1 = ref.message) != null ? ref1.trim() : void 0 : void 0) || ((typeof err === 'string' ? err : void 0) || err.message || 'Unknown error').trim();`

Transpiled using CS 1.10.1 (better handles `ref.message` being `undefined`):
`message = ((ref = err.json) != null ? ref.message : void 0) || ((typeof err === 'string' ? err : void 0) || err.message || 'Unknown error').trim();`

Better error after NPE fix:
![image](https://cloud.githubusercontent.com/assets/844249/18772554/07f26800-8116-11e6-9cde-2d88f2d65c0c.png)
